### PR TITLE
Fix: scene_id does not correspond in USDZ and Collision, e.g. 0001_839920.usdz with 839920/839920_collision.usd

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ python Code/benchmark/scene_data/sage3d_usda_builder.py \
     --usdz-placeholder "@usdz_root[gauss.usda]@" \
     --collision-placeholder "@collision_root@" \
     --usdz-path-template "/path/to/usdz/{scene_id}.usdz[gauss.usda]" \
-    --collision-path-template "/path/to/collision/{scene_id}/{scene_id}_collision.usd" \
+    --collision-path-template "/path/to/collision/{world_id}/{world_id}_collision.usd" \
     --overwrite
 ```
 


### PR DESCRIPTION
Since I was running the script to process USDZ to USDA, I found the matching rules between USDZ and Collision had something wrong:
* USDZ file has this format: e.g. `0001_839920.usdz`
* Collsion directory has this format: e.g. `Collision_Mesh/839920/839920_collision.usd`

Thus, when we use `Code/benchmark/scene_data/sage3d_usda_builder.py` to process these two files, we should just use the digital number after the underline in USDZ filename. I made some modification to make it work well, hope you can accept this. 
Have a nice day! :)
<img width="1138" height="636" alt="image-20251217100905211" src="https://github.com/user-attachments/assets/80923254-bbda-4edd-b1e6-3e32d0a7db2f" />
